### PR TITLE
Replace reshape2::melt with tidyr::pivot_longer in stack_params()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,6 @@ Imports:
     purrr,
     quantreg,
     readr,
-    reshape2,
     rtracklayer,
     S4Vectors,
     scales,

--- a/R/hmmcopy_utils.R
+++ b/R/hmmcopy_utils.R
@@ -400,8 +400,7 @@ stack_params <- function(data, paramname) {
   data <- data.frame(data)
   colnames(data) <- 1:length(data) - 1
   data$state <- as.numeric(row.names(data)) - 1
-  # TODO: Replace reshape2::melt with tidyr::pivot_longer here
-  data <- reshape2::melt(data, id.vars = "state", value.name = "value", variable.name = "iteration")
+  data <- tidyr::pivot_longer(data, cols = -state, names_to = "iteration", values_to = "value")
   data$parameter <- paramname
   return(data)
 }


### PR DESCRIPTION
Resolves the TODO in hmmcopy_utils.R by swapping the single reshape2
dependency for the already-imported tidyr, and removes reshape2 from
DESCRIPTION Imports since it is no longer used anywhere in the package.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NrE3jTuMAjTuXNXY5GzY34