### PR TITLE
fix(ci): prevent renv from poisoning CI dependency resolution

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,6 +36,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      RENV_ACTIVATE_PROJECT: "FALSE"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -1,8 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 # GitHub recommends pinning actions to a commit SHA.
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
@@ -21,22 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
-      
+        uses: actions/checkout@v4
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: zatzmanm/scatools
-      
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,6 +21,7 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RENV_ACTIVATE_PROJECT: "FALSE"
     permissions:
       contents: write
     steps:

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RENV_ACTIVATE_PROJECT: "FALSE"
     steps:
       - uses: actions/checkout@v4
 
@@ -52,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RENV_ACTIVATE_PROJECT: "FALSE"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
.Rprofile activates renv, which sets Bioconductor 3.18 repos for all R
processes in CI. pak/setup-r-dependencies then installs BioC 3.18
packages incompatible with current R/compilers, causing:
- zellkonverter 1.12.1 build failure on Windows (nzindex removed from DelayedArray)
- Biobase 2.62.0 C compilation failure on Ubuntu/GCC 13 (C23 standard removes Calloc/Free)
- Rtsne.so OpenMP linker failure on macOS pkgdown (stale renv cache)

Setting RENV_ACTIVATE_PROJECT=FALSE in each workflow prevents renv from
activating, letting setup-r-dependencies resolve current BioC versions.

Also update build_docker.yaml action versions (checkout v3→v4,
login-action v2→v3, metadata-action v4→v5, build-push-action v3→v6).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JsWkDJkndDV1GhsT1Um4fG