### PR TITLE
test: add testthat harness and core unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,8 +71,9 @@ Suggests:
     HGC,
     knitr,
     rmarkdown,
+    testthat (>= 3.0.0),
     zellkonverter
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 biocViews:
 Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(scatools)
+
+test_check("scatools")

--- a/tests/testthat/helper-toy-sce.R
+++ b/tests/testthat/helper-toy-sce.R
@@ -1,0 +1,29 @@
+# Shared fixtures for scatools unit tests.
+
+# A tiny SingleCellExperiment with 4 bins on chr1 and 3 cells.
+# The last bin is deliberately half-width to exercise length normalization.
+make_toy_sce <- function() {
+  m <- matrix(
+    c(
+      1, 2, 3, 4, # cell1
+      2, 4, 6, 8, # cell2
+      10, 10, 10, 10 # cell3
+    ),
+    nrow = 4, ncol = 3,
+    dimnames = list(paste0("bin", 1:4), paste0("cell", 1:3))
+  )
+  gr <- GenomicRanges::GRanges(
+    seqnames = "chr1",
+    ranges = IRanges::IRanges(
+      start = c(1, 101, 201, 301),
+      end = c(100, 200, 300, 350) # widths 100, 100, 100, 50
+    )
+  )
+  sce <- SingleCellExperiment::SingleCellExperiment(
+    assays = list(counts = m),
+    rowRanges = gr
+  )
+  rownames(sce) <- rownames(m)
+  colnames(sce) <- colnames(m)
+  sce
+}

--- a/tests/testthat/test-bin_utils.R
+++ b/tests/testthat/test-bin_utils.R
@@ -1,0 +1,58 @@
+test_that("is_valid_bin flags bins on read count and N frequency", {
+  valid <- is_valid_bin(
+    counts = c(0, 5, 10),
+    n_freq = c(0, 0, 0.1),
+    min_reads = 1,
+    max_N_freq = 0.05
+  )
+  expect_equal(valid, c(FALSE, TRUE, FALSE))
+})
+
+test_that("is_ideal_bin returns valid/ideal invariants", {
+  counts <- c(0, 5, 100, 5, 6)
+  gc <- c(0.4, 0.5, 0.5, 0.5, 0.5)
+  n_freq <- c(0, 0, 0, 0.1, 0)
+
+  res <- is_ideal_bin(counts, gc, n_freq, min_reads = 1, max_N_freq = 0.05)
+
+  expect_s3_class(res, "data.frame")
+  expect_named(res, c("ideal", "valid"))
+  expect_equal(nrow(res), length(counts))
+
+  # valid column must agree with is_valid_bin
+  expect_equal(res$valid, is_valid_bin(counts, n_freq, min_reads = 1, max_N_freq = 0.05))
+
+  # ideal bins are always a subset of valid bins
+  expect_true(all(res$valid[res$ideal]))
+
+  # a zero-count bin can never be valid or ideal
+  expect_false(res$valid[1])
+  expect_false(res$ideal[1])
+})
+
+test_that("bin id encode/decode round-trips", {
+  gr <- GenomicRanges::GRanges(
+    seqnames = c("chr1", "chr2"),
+    ranges = IRanges::IRanges(start = c(1, 201), end = c(100, 300))
+  )
+  ids <- get_bin_ids(gr)
+  expect_equal(ids, c("chr1_1_100", "chr2_201_300"))
+
+  info <- get_bin_info(ids)
+  expect_equal(as.character(info$chr), c("chr1", "chr2"))
+  expect_equal(info$start, c(1, 201))
+  expect_equal(info$end, c(100, 300))
+})
+
+test_that("length_normalize rescales only variable-width bins", {
+  sce <- make_toy_sce()
+  res <- length_normalize(sce, assay_name = "counts", assay_to = "counts_lenNorm")
+
+  norm <- SummarizedExperiment::assay(res, "counts_lenNorm")
+  orig <- SummarizedExperiment::assay(sce, "counts")
+
+  # bins 1-3 are the modal width (100) -> unchanged
+  expect_equal(norm[1:3, ], orig[1:3, ])
+  # bin 4 is half width (50) -> counts doubled
+  expect_equal(norm[4, ], orig[4, ] * 2)
+})

--- a/tests/testthat/test-cnv_tools.R
+++ b/tests/testthat/test-cnv_tools.R
@@ -1,0 +1,35 @@
+test_that("calc_ratios divides each cell by its own centre", {
+  sce <- make_toy_sce()
+  res <- calc_ratios(sce, assay_name = "counts", fun = "mean")
+  ratios <- SummarizedExperiment::assay(res, "counts_ratios")
+
+  # cell1 counts c(1,2,3,4), mean 2.5 -> c(0.4,0.8,1.2,1.6)
+  expect_equal(unname(ratios[, "cell1"]), c(0.4, 0.8, 1.2, 1.6))
+  # cell3 is flat -> all ratios 1
+  expect_equal(unname(ratios[, "cell3"]), c(1, 1, 1, 1))
+})
+
+test_that("logNorm applies the requested log transform", {
+  sce <- make_toy_sce()
+  SummarizedExperiment::assay(sce, "myratios") <- SummarizedExperiment::assay(sce, "counts")
+
+  res <- logNorm(sce, transform = "log2", assay_name = "myratios", name = "mylog")
+  out <- SummarizedExperiment::assay(res, "mylog")
+
+  expect_equal(unname(out[, "cell1"]), round(log2(c(1, 2, 3, 4)), 2))
+  expect_equal(unname(out[, "cell3"]), round(log2(c(10, 10, 10, 10)), 2))
+})
+
+test_that("logNorm replaces zeros before logging (no -Inf)", {
+  sce <- make_toy_sce()
+  m <- SummarizedExperiment::assay(sce, "counts")
+  m[1, 1] <- 0
+  SummarizedExperiment::assay(sce, "myratios") <- m
+
+  res <- logNorm(sce, transform = "log2", assay_name = "myratios", name = "mylog")
+  out <- SummarizedExperiment::assay(res, "mylog")
+
+  expect_true(all(is.finite(out)))
+  # 0 -> 1e-3 -> log2(1e-3)
+  expect_equal(out[1, 1], round(log2(1e-3), 2))
+})

--- a/tests/testthat/test-gc_correction.R
+++ b/tests/testthat/test-gc_correction.R
@@ -1,0 +1,31 @@
+test_that("gc_cor_modal reduces GC bias and preserves length", {
+  skip_if_not_installed("quantreg")
+  skip_if_not_installed("polynom")
+
+  set.seed(42)
+  n <- 300
+  gc <- runif(n, 0.35, 0.65)
+  # Flat underlying copy number with a strong multiplicative GC bias.
+  counts <- 100 * (1 + 1.5 * (gc - 0.5)) * exp(rnorm(n, 0, 0.05))
+  counts <- pmax(counts, 1)
+
+  corrected <- gc_cor_modal(counts = counts, gc = gc, results = "counts")
+
+  expect_length(corrected, n)
+
+  ok <- is.finite(corrected)
+  expect_gt(sum(ok), n * 0.8) # most bins should be corrected
+
+  raw_cor <- abs(stats::cor(counts, gc))
+  corrected_cor <- abs(stats::cor(corrected[ok], gc[ok]))
+
+  # Correction should substantially weaken the GC-count relationship.
+  expect_lt(corrected_cor, raw_cor)
+})
+
+test_that("gc_cor_modal errors on mismatched input lengths", {
+  expect_error(
+    gc_cor_modal(counts = 1:10, gc = 1:5),
+    "identical"
+  )
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,12 @@
+test_that("getmode returns the most frequent value", {
+  expect_equal(getmode(c(1, 1, 2)), 1)
+  expect_equal(getmode(c(5, 5, 5, 3, 3)), 5)
+  expect_equal(getmode(c("a", "b", "b")), "b")
+})
+
+test_that("prettyMb formats genomic distances with the right unit", {
+  expect_equal(prettyMb(1e7), "10Mb")
+  expect_equal(prettyMb(5e5), "500Kb")
+  expect_equal(prettyMb(1e3), "1Kb")
+  expect_equal(prettyMb(2.5e8), "250Mb")
+})


### PR DESCRIPTION
First tests for the package (it declared `Config/testthat/edition: 3` but shipped none).

### Coverage (deterministic core)
- **utils**: `getmode`, `prettyMb`
- **bin_utils**: `is_valid_bin`, `is_ideal_bin` invariants, bin-id encode/decode round-trip, `length_normalize` (variable-width rescaling)
- **cnv_tools**: `calc_ratios`, `logNorm` (incl. zero handling)
- **gc_correction**: `gc_cor_modal` reduces GC bias, preserves length, errors on mismatched input

Adds `testthat (>= 3.0.0)` to Suggests. ~31 assertions, all pass locally on R 4.3.

Tumor-data integration tests (real CNV concordance) will follow once benchmark datasets are selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)