### PR TITLE
benchmark: dataset registry + evaluation harness scaffold

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,6 +12,7 @@
 ^\.vscode$
 ^example$
 ^results$
+^benchmarks$
 Dockerfile
 ^docker*
 ^dev$

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,10 @@
+# Benchmark data lives outside git (SCATOOLS_BENCH_DATA); never commit it.
+data/
+results/
+*.tsv.gz
+*.mtx
+*.mtx.gz
+*.rds
+*.h5ad
+*.bam
+*.bai

--- a/benchmarks/R/evaluate_cnv.R
+++ b/benchmarks/R/evaluate_cnv.R
@@ -1,0 +1,109 @@
+# Dataset-agnostic concordance metrics: scatools CN vs ground truth.
+#
+# The truth is provided as a GRanges carrying a copy-number signal column; this
+# harness rebins it onto the scatools query bins (reusing scatools::integrate_segments)
+# and computes correlation + gain/loss classification concordance.
+
+#' Pseudobulk (or clone-level) per-bin profile from a scatools SCE.
+#'
+#' @param sce scatools SingleCellExperiment
+#' @param assay_name assay holding relative CN / logratios (e.g. "logr_modal")
+#' @param group_by optional colData column; if given, returns one column per group
+#' @return GRanges (rowRanges of sce) with a `signal` column (or one per group)
+pseudobulk_profile <- function(sce, assay_name, group_by = NULL) {
+  gr <- SummarizedExperiment::rowRanges(sce)
+  m <- SummarizedExperiment::assay(sce, assay_name)
+  if (is.null(group_by)) {
+    S4Vectors::mcols(gr)$signal <- Matrix::rowMeans(m, na.rm = TRUE)
+  } else {
+    ids <- sce[[group_by]]
+    for (g in unique(ids)) {
+      S4Vectors::mcols(gr)[[paste0("signal_", g)]] <-
+        Matrix::rowMeans(m[, ids == g, drop = FALSE], na.rm = TRUE)
+    }
+  }
+  gr
+}
+
+#' Rebin a truth CN GRanges onto query bins (weighted mean over overlaps).
+#'
+#' Dogfoods scatools::integrate_segments.
+#' @param query_bins GRanges of scatools bins
+#' @param truth_gr GRanges with a numeric CN/signal column
+#' @param signal_col name of the signal column in truth_gr
+#' @return query_bins with an integrated `truth` column
+rebin_truth <- function(query_bins, truth_gr, signal_col) {
+  out <- scatools::integrate_segments(
+    x = query_bins,
+    y = truth_gr,
+    granges_signal_colname = signal_col,
+    drop_na = FALSE
+  )
+  out
+}
+
+#' Classify a CN signal into loss / neutral / gain.
+#'
+#' @param x numeric signal
+#' @param mode "logratio" (thresholds around 0) or "integer" (around ploidy)
+#' @param t threshold (logratio) — |x| < t is neutral
+#' @param ploidy baseline for integer mode
+classify_cn <- function(x, mode = c("logratio", "integer"), t = 0.15, ploidy = 2) {
+  mode <- match.arg(mode)
+  center <- if (mode == "logratio") 0 else ploidy
+  tol <- if (mode == "logratio") t else 0.5
+  out <- rep("neutral", length(x))
+  out[x > center + tol] <- "gain"
+  out[x < center - tol] <- "loss"
+  factor(out, levels = c("loss", "neutral", "gain"))
+}
+
+#' Evaluate scatools CN against a truth profile on shared bins.
+#'
+#' @param query_gr GRanges from pseudobulk_profile() with a `signal` column (scatools)
+#' @param truth_gr GRanges with a truth CN column
+#' @param query_col signal column in query_gr
+#' @param truth_col signal column in truth_gr
+#' @param query_mode,truth_mode "logratio" or "integer" for classification
+#' @return one-row data.frame of concordance metrics
+evaluate_cnv <- function(query_gr, truth_gr,
+                         query_col = "signal", truth_col = "cn",
+                         query_mode = "logratio", truth_mode = "integer") {
+  # Put truth onto the query bins.
+  merged <- rebin_truth(query_gr, truth_gr, signal_col = truth_col)
+
+  q <- S4Vectors::mcols(merged)[[query_col]]
+  tr <- S4Vectors::mcols(merged)[[truth_col]]
+
+  ok <- is.finite(q) & is.finite(tr)
+  q <- q[ok]; tr <- tr[ok]
+  if (length(q) < 10) stop("Too few overlapping bins to evaluate (", length(q), ")")
+
+  # Continuous concordance
+  pearson <- suppressWarnings(stats::cor(q, tr, method = "pearson"))
+  spearman <- suppressWarnings(stats::cor(q, tr, method = "spearman"))
+
+  # Categorical concordance (gain/neutral/loss)
+  qc <- classify_cn(q, mode = query_mode)
+  tc <- classify_cn(tr, mode = truth_mode)
+  tab <- table(truth = tc, query = qc)
+  accuracy <- sum(diag(tab)) / sum(tab)
+  kappa <- cohen_kappa(tab)
+
+  data.frame(
+    n_bins = length(q),
+    pearson = round(pearson, 3),
+    spearman = round(spearman, 3),
+    class_accuracy = round(accuracy, 3),
+    kappa = round(kappa, 3)
+  )
+}
+
+#' Cohen's kappa from a square confusion matrix.
+cohen_kappa <- function(tab) {
+  n <- sum(tab)
+  po <- sum(diag(tab)) / n
+  pe <- sum(rowSums(tab) * colSums(tab)) / n^2
+  if (isTRUE(all.equal(pe, 1))) return(NA_real_)
+  (po - pe) / (1 - pe)
+}

--- a/benchmarks/R/manifest.R
+++ b/benchmarks/R/manifest.R
@@ -1,0 +1,67 @@
+# Read the benchmark dataset registry and resolve on-disk paths.
+# Data lives outside git under SCATOOLS_BENCH_DATA.
+
+#' Root directory for benchmark data (outside git).
+bench_data_root <- function() {
+  root <- Sys.getenv("SCATOOLS_BENCH_DATA", unset = "")
+  if (!nzchar(root)) {
+    root <- file.path(path.expand("~"), "work", "scatools_benchmark_data")
+  }
+  root
+}
+
+#' Read datasets.yaml into a list of dataset entries.
+read_manifest <- function(path = file.path(dirname(dirname(this_dir())), "datasets.yaml")) {
+  if (!requireNamespace("yaml", quietly = TRUE)) {
+    stop("Package 'yaml' is required to read the benchmark manifest.")
+  }
+  yaml::read_yaml(path)$datasets
+}
+
+#' Resolve the on-disk directories for a dataset id.
+dataset_paths <- function(id, create = FALSE) {
+  base <- file.path(bench_data_root(), id)
+  paths <- list(
+    base = base,
+    atac = file.path(base, "atac"),
+    truth = file.path(base, "truth"),
+    results = file.path(base, "results")
+  )
+  if (create) {
+    lapply(paths, dir.create, showWarnings = FALSE, recursive = TRUE)
+  }
+  paths
+}
+
+#' Look up a single dataset entry by id.
+get_dataset <- function(id, manifest = read_manifest()) {
+  ids <- vapply(manifest, `[[`, character(1), "id")
+  hit <- manifest[[which(ids == id)]]
+  if (is.null(hit)) stop(sprintf("Dataset '%s' not found in manifest", id))
+  hit
+}
+
+#' Tabular overview of the registry: id, aneuploidy class, truth type, status.
+list_datasets <- function(manifest = read_manifest()) {
+  do.call(rbind, lapply(manifest, function(d) {
+    data.frame(
+      id = d$id %||% NA,
+      aneuploidy = d$aneuploidy %||% NA,
+      assay = d$assay %||% NA,
+      truth = (d$truth$type %||% NA),
+      status = d$status %||% NA,
+      stringsAsFactors = FALSE
+    )
+  }))
+}
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+# Best-effort location of this script's directory (for default manifest path).
+this_dir <- function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  f <- sub("^--file=", "", args[grep("^--file=", args)])
+  if (length(f)) return(dirname(normalizePath(f)))
+  # Fall back to the conventional repo location.
+  "benchmarks/R"
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,70 @@
+# scatools benchmarks
+
+Reproducible copy-number benchmarking for `scatools` against public and
+in-house tumor scATAC datasets with orthogonal ground-truth copy number.
+
+This directory holds **only** the registry, scripts, and evaluation harness.
+The actual data (fragments, matrices, truth CN, results) lives **outside git**
+under a data root, because the files are large.
+
+## Design goals
+
+- **Span the aneuploidy spectrum.** Datasets are tagged `normal` → `quiet` →
+  `moderate` → `high` so we test both *specificity* (don't hallucinate CNVs in
+  near-diploid genomes) and *sensitivity* (resolve complex aneuploidy).
+- **Multiple ground-truth modalities.** Concordance is computed against whatever
+  truth a dataset has: matched single-cell DNA (**DLP+**, the strongest — per-cell
+  integer CN), bulk WGS/WES segments, multiome GEX-derived CN, SNP array, or a
+  known karyotype.
+- **One registry, many datasets.** Every dataset is a row in
+  [`datasets.yaml`](datasets.yaml). Adding a dataset = adding an entry + a prep
+  script; the harness is dataset-agnostic.
+
+## Layout
+
+```
+benchmarks/
+  README.md
+  datasets.yaml          # the dataset registry (source of truth)
+  R/
+    manifest.R           # read the registry, resolve on-disk paths
+    evaluate_cnv.R       # truth adapters + concordance metrics
+  scripts/
+    download_<id>.sh     # per-dataset fetch/prep (one per dataset)
+    run_benchmark.R      # run scatools on a dataset -> results
+```
+
+Data root (NOT in git), set via `SCATOOLS_BENCH_DATA`
+(default `~/work/scatools_benchmark_data`):
+
+```
+$SCATOOLS_BENCH_DATA/<dataset_id>/
+  atac/        # fragments.tsv.gz / peak or bin matrix
+  truth/       # ground-truth CN (DLP, WGS segments, ...)
+  results/     # scatools output + evaluation
+```
+
+## Ground-truth modalities
+
+| type          | source                              | resolution      |
+|---------------|-------------------------------------|-----------------|
+| `scDNA_DLP`   | Shah lab DLP+ (SIGNALS/HMMcopy)     | per-cell integer CN |
+| `scWGS`       | single-cell WGS (non-DLP)           | per-cell / consensus |
+| `bulk_wgs`    | matched bulk WGS/WES segments       | segment-level   |
+| `multiome_gex`| paired GEX (inferCNV/Numbat)        | in-cell, coarse |
+| `snp_array`   | SNP array CN                        | segment-level   |
+| `karyotype`   | known/published karyotype           | arm-level       |
+
+## Adding a dataset
+
+1. Add an entry to `datasets.yaml` (id, aneuploidy class, atac source/format,
+   truth type + accession).
+2. Write `scripts/download_<id>.sh` that populates
+   `$SCATOOLS_BENCH_DATA/<id>/atac/` and `.../truth/`.
+3. Run the benchmark (`scripts/run_benchmark.R <id>`), which runs scatools and
+   calls the evaluation harness.
+
+## Status
+
+Bootstrapping. See `datasets.yaml` for the current spectrum and per-dataset
+`status` (`pending` → `downloaded` → `processed` → `benchmarked`).

--- a/benchmarks/datasets.yaml
+++ b/benchmarks/datasets.yaml
@@ -1,0 +1,116 @@
+# scatools benchmark dataset registry.
+#
+# Ordered roughly along the aneuploidy spectrum: normal -> quiet -> moderate -> high.
+# aneuploidy: normal | quiet | moderate | high
+# atac.format: fragments | peak_matrix | bin_matrix | fastq
+# truth.type:  scDNA_DLP | scWGS | bulk_wgs | multiome_gex | snp_array | karyotype
+# status:      pending | downloaded | processed | benchmarked
+#
+# Accessions marked (VERIFY) are pending confirmation of exact IDs / download format.
+
+datasets:
+
+  - id: pbmc_10k_normal
+    name: 10x PBMC (healthy) scATAC — negative control
+    cancer_type: none
+    assay: scATAC
+    aneuploidy: normal
+    n_cells: ~10000
+    genome: hg38
+    role: specificity_control      # method must return a FLAT, no-CNV profile
+    atac:
+      source: 10x
+      url: https://www.10xgenomics.com/datasets   # (VERIFY exact PBMC ATAC page)
+      format: fragments
+    truth:
+      type: karyotype
+      value: diploid
+    status: pending
+
+  - id: hct116
+    name: HCT116 colorectal (MSI, near-diploid)
+    cancer_type: colorectal
+    assay: scATAC
+    aneuploidy: quiet
+    n_cells: ~1000
+    genome: hg38
+    atac:
+      source: sra
+      accession: SRP167062          # (VERIFY format: fragments vs fastq)
+      format: fastq
+    truth:
+      type: scWGS
+      accession: PRJEB27084
+    notes: near-diploid MSI line; tests low-false-positive behavior
+    status: pending
+
+  - id: bcc_su008
+    name: Basal cell carcinoma SU008 (Satpathy/Granja 2019)
+    cancer_type: BCC
+    assay: scATAC
+    aneuploidy: moderate
+    n_cells: ~500
+    genome: hg38
+    atac:
+      source: geo
+      accession: GSE129785
+      format: fragments             # (VERIFY: fragments provided in supplement)
+    truth:
+      type: bulk_wgs
+      notes: allele-specific reference from Alleloscope on BCC samples
+    status: pending
+
+  - id: snu601
+    name: SNU601 gastric carcinoma (highly aneuploid)
+    cancer_type: gastric
+    assay: scATAC
+    aneuploidy: high
+    n_cells: ~3500
+    genome: hg38
+    role: primary_benchmark        # shared benchmark of epiAneufinder + Alleloscope
+    atac:
+      source: alleloscope_github    # (VERIFY: processed matrix vs SRA fastq)
+      accession: PRJNA674903
+      url: https://github.com/seasoncloud/Alleloscope
+      format: bin_matrix
+    truth:
+      type: scWGS
+      accession: PRJNA498809
+      notes: allele-specific + copy-neutral-LOH events pre-characterized
+    status: pending
+
+  - id: colo320hsr
+    name: COLO320HSR colorectal (MYC ecDNA, extreme focal amp)
+    cancer_type: colorectal
+    assay: scATAC
+    aneuploidy: high
+    n_cells: ~1000
+    genome: hg38
+    atac:
+      source: sra
+      accession: PRJNA672109        # (VERIFY)
+      format: fastq
+    truth:
+      type: scWGS
+      accession: PRJNA506071
+    notes: massive MYC ecDNA amplification — extreme focal-amplification test case
+    status: pending
+
+  # ---- In-house (Shah lab) — gold-standard matched DLP+ scWGS + scATAC ----
+  # One entry per specimen once available. Truth = per-cell integer CN from DLP+
+  # (SIGNALS/HMMcopy). These are the strongest concordance references.
+  - id: inhouse_TEMPLATE
+    name: In-house specimen (matched DLP+ / scATAC)
+    cancer_type: TBD
+    assay: scATAC
+    aneuploidy: TBD
+    genome: hg38
+    role: gold_standard
+    atac:
+      source: inhouse
+      path: TBD                      # local fragments path
+      format: fragments
+    truth:
+      type: scDNA_DLP
+      path: TBD                      # SIGNALS/HMMcopy per-cell CN
+    status: template

--- a/benchmarks/datasets.yaml
+++ b/benchmarks/datasets.yaml
@@ -6,95 +6,83 @@
 # truth.type:  scDNA_DLP | scWGS | bulk_wgs | multiome_gex | snp_array | karyotype
 # status:      pending | downloaded | processed | benchmarked
 #
-# Accessions marked (VERIFY) are pending confirmation of exact IDs / download format.
+# Accessions verified live 2026-07-10 unless marked (VERIFY).
 
 datasets:
 
-  - id: pbmc_10k_normal
-    name: 10x PBMC (healthy) scATAC — negative control
+  - id: pbmc_5k_normal
+    name: 10x PBMC 5k (healthy) scATAC — euploid negative control
     cancer_type: none
     assay: scATAC
     aneuploidy: normal
-    n_cells: ~10000
+    n_cells: ~4600
     genome: hg38
-    role: specificity_control      # method must return a FLAT, no-CNV profile
+    role: specificity_control      # must return a FLAT, no-CNV profile
     atac:
       source: 10x
-      url: https://www.10xgenomics.com/datasets   # (VERIFY exact PBMC ATAC page)
-      format: fragments
+      url: https://cf.10xgenomics.com/samples/cell-atac/1.2.0/atac_pbmc_5k_nextgem/atac_pbmc_5k_nextgem_fragments.tsv.gz
+      format: fragments            # ~961 MB, direct download, no cellranger
     truth:
       type: karyotype
       value: diploid
+    notes: turnkey; the primary specificity test
     status: pending
 
-  - id: hct116
-    name: HCT116 colorectal (MSI, near-diploid)
-    cancer_type: colorectal
+  - id: snu601
+    name: SNU601 gastric carcinoma (highly aneuploid) — primary benchmark
+    cancer_type: gastric
     assay: scATAC
+    aneuploidy: high
+    n_cells: 3515
+    genome: hg38
+    role: primary_benchmark        # shared benchmark of epiAneufinder + Alleloscope
+    atac:
+      source: alleloscope_github
+      url: https://github.com/seasoncloud/Alleloscope    # samples/SNU601/scATAC/
+      accession: PRJNA674903       # raw FASTQ (fallback); processed matrices in repo
+      format: bin_matrix           # chr200k_fragments_sub.txt + SNP ref/alt matrices
+    truth:
+      type: scWGS                  # matched 10x single-cell genome (Andor 2020)
+      accession: PRJNA498809
+      notes: scDNA HMM segments; allele-specific + copy-neutral-LOH pre-characterized
+    status: pending
+
+  - id: colo320dm
+    name: COLO320DM colorectal — MYC ecDNA (extreme focal amp)
+    cancer_type: colorectal
+    assay: multiome
+    aneuploidy: high
+    n_cells: ~72000               # DM + HSR combined in series
+    genome: hg38
+    role: extreme_focal
+    atac:
+      source: geo
+      accession: GSE159986         # PRJNA672109; Hung et al. Nature 2021
+      url: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE159986
+      format: matrix               # in GSE159986_RAW.tar (~18.7 GB)
+    truth:
+      type: bulk_wgs
+      notes: WGS + Nanopore + MYC-FISH; scATAC CN up to ~237 (ecDNA)
+    status: pending
+
+  # --- Quiet / near-diploid rung: accession NOT yet confirmed ---
+  - id: hct116
+    name: HCT116 colorectal (MSI, near-diploid) — quiet-tumor control
+    cancer_type: colorectal
+    assay: multiome
     aneuploidy: quiet
-    n_cells: ~1000
+    n_cells: ~few thousand
     genome: hg38
     atac:
-      source: sra
-      accession: SRP167062          # (VERIFY format: fragments vs fastq)
+      source: geo
+      accession: VERIFY            # SRP167062 was a MISATTRIBUTION (mouse data);
+      url: https://doi.org/10.5281/zenodo.8032096   # confirm via epiAneufinder Zenodo/GitHub
       format: fastq
     truth:
       type: scWGS
       accession: PRJEB27084
-    notes: near-diploid MSI line; tests low-false-positive behavior
-    status: pending
-
-  - id: bcc_su008
-    name: Basal cell carcinoma SU008 (Satpathy/Granja 2019)
-    cancer_type: BCC
-    assay: scATAC
-    aneuploidy: moderate
-    n_cells: ~500
-    genome: hg38
-    atac:
-      source: geo
-      accession: GSE129785
-      format: fragments             # (VERIFY: fragments provided in supplement)
-    truth:
-      type: bulk_wgs
-      notes: allele-specific reference from Alleloscope on BCC samples
-    status: pending
-
-  - id: snu601
-    name: SNU601 gastric carcinoma (highly aneuploid)
-    cancer_type: gastric
-    assay: scATAC
-    aneuploidy: high
-    n_cells: ~3500
-    genome: hg38
-    role: primary_benchmark        # shared benchmark of epiAneufinder + Alleloscope
-    atac:
-      source: alleloscope_github    # (VERIFY: processed matrix vs SRA fastq)
-      accession: PRJNA674903
-      url: https://github.com/seasoncloud/Alleloscope
-      format: bin_matrix
-    truth:
-      type: scWGS
-      accession: PRJNA498809
-      notes: allele-specific + copy-neutral-LOH events pre-characterized
-    status: pending
-
-  - id: colo320hsr
-    name: COLO320HSR colorectal (MYC ecDNA, extreme focal amp)
-    cancer_type: colorectal
-    assay: scATAC
-    aneuploidy: high
-    n_cells: ~1000
-    genome: hg38
-    atac:
-      source: sra
-      accession: PRJNA672109        # (VERIFY)
-      format: fastq
-    truth:
-      type: scWGS
-      accession: PRJNA506071
-    notes: massive MYC ecDNA amplification — extreme focal-amplification test case
-    status: pending
+      notes: modal chromosome # 45; MLH1-deficient MSI, chromosomally stable
+    status: blocked                # needs accession verification before use
 
   # ---- In-house (Shah lab) — gold-standard matched DLP+ scWGS + scATAC ----
   # One entry per specimen once available. Truth = per-cell integer CN from DLP+
@@ -108,9 +96,9 @@ datasets:
     role: gold_standard
     atac:
       source: inhouse
-      path: TBD                      # local fragments path
+      path: TBD                    # local fragments path
       format: fragments
     truth:
       type: scDNA_DLP
-      path: TBD                      # SIGNALS/HMMcopy per-cell CN
+      path: TBD                    # SIGNALS/HMMcopy per-cell CN
     status: template

--- a/benchmarks/scripts/download_pbmc_5k_normal.sh
+++ b/benchmarks/scripts/download_pbmc_5k_normal.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fetch the 10x PBMC 5k scATAC fragments (euploid negative control).
+# ~961 MB. No cellranger needed.
+set -euo pipefail
+
+ID=pbmc_5k_normal
+ROOT="${SCATOOLS_BENCH_DATA:-$HOME/work/scatools_benchmark_data}"
+ATAC="$ROOT/$ID/atac"
+mkdir -p "$ATAC"
+
+BASE=https://cf.10xgenomics.com/samples/cell-atac/1.2.0/atac_pbmc_5k_nextgem
+FRAG="$ATAC/fragments.tsv.gz"
+
+if [[ -s "$FRAG" ]]; then
+  echo "[$ID] fragments already present: $FRAG"
+else
+  echo "[$ID] downloading fragments (~961 MB) -> $FRAG"
+  wget -q --show-progress -O "$FRAG" "$BASE/atac_pbmc_5k_nextgem_fragments.tsv.gz"
+fi
+
+# Tabix index (optional; scatools reads the fragments directly)
+if [[ ! -s "$FRAG.tbi" ]]; then
+  wget -q -O "$FRAG.tbi" "$BASE/atac_pbmc_5k_nextgem_fragments.tsv.gz.tbi" || \
+    echo "[$ID] note: .tbi not fetched (not required)"
+fi
+
+echo "[$ID] done. Truth = diploid (no CNVs expected)."

--- a/benchmarks/scripts/download_snu601.sh
+++ b/benchmarks/scripts/download_snu601.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Fetch SNU601 gastric scATAC processed matrices + matched scDNA truth from the
+# Alleloscope repository (github.com/seasoncloud/Alleloscope, samples/SNU601).
+# Processed data -> no cellranger needed. Raw FASTQ fallback: SRA PRJNA674903.
+set -euo pipefail
+
+ID=snu601
+ROOT="${SCATOOLS_BENCH_DATA:-$HOME/work/scatools_benchmark_data}"
+BASE="$ROOT/$ID"
+ATAC="$BASE/atac"; TRUTH="$BASE/truth"
+mkdir -p "$ATAC" "$TRUTH"
+
+REPO="$BASE/Alleloscope"
+if [[ ! -d "$REPO/.git" ]]; then
+  echo "[$ID] sparse-cloning Alleloscope samples/SNU601 ..."
+  git clone --depth 1 --filter=blob:none --sparse \
+    https://github.com/seasoncloud/Alleloscope.git "$REPO"
+  git -C "$REPO" sparse-checkout set samples/SNU601
+else
+  echo "[$ID] Alleloscope repo already present: $REPO"
+fi
+
+SRC="$REPO/samples/SNU601"
+if [[ -d "$SRC" ]]; then
+  # scATAC: bin-by-cell fragment counts + SNP ref/alt matrices, barcodes, VCF
+  cp -rn "$SRC/scATAC/." "$ATAC/" 2>/dev/null || true
+  # scDNA truth (matched single-cell genome; HMM CN segments)
+  cp -rn "$SRC/scDNA/." "$TRUTH/" 2>/dev/null || true
+  echo "[$ID] copied processed matrices:"
+  ls -1 "$ATAC" | sed 's/^/    atac: /'
+  ls -1 "$TRUTH" | sed 's/^/    truth: /'
+else
+  echo "[$ID] WARNING: $SRC not found — verify the sparse-checkout path in the repo."
+  echo "[$ID] Raw FASTQ fallback: SRA PRJNA674903 (requires cellranger-atac)."
+fi
+
+echo "[$ID] done. Truth = matched scDNA (Andor 2020, PRJNA498809)."

--- a/benchmarks/scripts/run_benchmark.R
+++ b/benchmarks/scripts/run_benchmark.R
@@ -1,0 +1,63 @@
+#!/usr/bin/env Rscript
+# Run scatools on a benchmark dataset and evaluate against ground truth.
+#
+# Usage: Rscript benchmarks/scripts/run_benchmark.R <dataset_id> [assay_name]
+#
+# Expects the dataset's atac/ and truth/ dirs to be populated under
+# SCATOOLS_BENCH_DATA (see benchmarks/scripts/download_<id>.sh).
+
+suppressPackageStartupMessages({
+  library(scatools)
+})
+source(file.path("benchmarks", "R", "manifest.R"))
+source(file.path("benchmarks", "R", "evaluate_cnv.R"))
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1) stop("Usage: run_benchmark.R <dataset_id> [assay_name]")
+id <- args[[1]]
+assay_name <- if (length(args) >= 2) args[[2]] else "logr_modal"
+
+ds <- get_dataset(id)
+paths <- dataset_paths(id, create = TRUE)
+cli::cli_alert_info("Benchmarking dataset '{id}' ({ds$aneuploidy} aneuploidy)")
+
+# 1) Run scatools on the ATAC fragments -----------------------------------
+#    (Assumes atac/ holds a fragments.tsv.gz; adapt per dataset format.)
+frag <- list.files(paths$atac, pattern = "fragments.*tsv.gz$", full.names = TRUE)
+if (length(frag) != 1) {
+  cli::cli_abort("Expected exactly one fragments file in {paths$atac}; found {length(frag)}")
+}
+
+bins <- get(data(bins_10mb))
+sce <- run_scatools(
+  sample_id = id,
+  fragment_file = frag,
+  bins = bins,
+  outdir = paths$results,
+  segment = TRUE,
+  save_h5ad = FALSE
+)
+
+# 2) scatools pseudobulk / tumor profile ----------------------------------
+query_gr <- pseudobulk_profile(sce[, sce$tumor_cell %in% TRUE], assay_name = assay_name)
+
+# 3) Load ground truth (adapter per truth type) ---------------------------
+#    TODO: implement load_truth_cn(ds, paths$truth) dispatching on ds$truth$type:
+#      scDNA_DLP -> per-cell integer CN (SIGNALS/HMMcopy) -> clone consensus GRanges
+#      bulk_wgs  -> segment GRanges
+#      multiome_gex -> inferCNV/Numbat profile
+truth_gr <- NULL
+if (is.null(truth_gr)) {
+  cli::cli_alert_warning("No truth adapter wired for '{ds$truth$type}' yet — skipping evaluation.")
+  quit(save = "no")
+}
+
+# 4) Evaluate -------------------------------------------------------------
+metrics <- evaluate_cnv(query_gr, truth_gr,
+  query_col = "signal", truth_col = "cn",
+  query_mode = "logratio", truth_mode = "integer"
+)
+metrics$dataset <- id
+print(metrics)
+saveRDS(metrics, file.path(paths$results, "metrics.rds"))
+cli::cli_alert_success("Benchmark complete for '{id}'")


### PR DESCRIPTION
Scaffolds a reproducible CNV benchmarking system (dev tooling; `benchmarks/` is `.Rbuildignore`'d).

- **`datasets.yaml`** — dataset registry (source of truth).
- **`R/manifest.R`** — read the registry, resolve on-disk paths (data lives outside git under `SCATOOLS_BENCH_DATA`).
- **`R/evaluate_cnv.R`** — dataset-agnostic concordance metrics (Pearson/Spearman + gain/loss classification accuracy/κ); rebins truth onto scatools bins via `scatools::integrate_segments`.
- **`scripts/run_benchmark.R`** — orchestrator skeleton.