### PR TITLE
refactor: demote heavy Bioc deps to Suggests with guards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,17 +14,13 @@ Imports:
     BiocGenerics,
     BiocNeighbors,
     BiocParallel,
-    circlize,
     cli,
-    ComplexHeatmap,
     data.table,
     DNAcopy,
     dplyr,
-    EnsDb.Hsapiens.v86,
     GenomeInfoDb,
     GenomicFeatures,
     GenomicRanges,
-    GGally,
     ggplot2,
     glue,
     HMMcopy,
@@ -54,16 +50,20 @@ Imports:
     tidyr,
     utils,
     uwot,
-    vcfR,
     withr
-Suggests: 
+Suggests:
     anndata,
     BSgenome,
     BSgenome.Hsapiens.UCSC.hg38,
+    circlize,
+    ComplexHeatmap,
     dittoSeq,
+    EnsDb.Hsapiens.v86,
+    GGally,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
+    vcfR,
     zellkonverter
 VignetteBuilder:
     knitr

--- a/R/colors.R
+++ b/R/colors.R
@@ -22,10 +22,12 @@ state_cn_colors <- function() {
 #' @export
 #'
 logr_col_fun <- function(breaks = c(-2, 0, 2), colors = c("blue", "white", "red")) {
+  require_ns("circlize", "heatmap colour scales")
   circlize::colorRamp2(breaks = breaks, colors = colors)
 }
 
 counts_col_fun <- function(breaks = c(0, 2, 8), colors = c("blue", "white", "red")) {
+  require_ns("circlize", "heatmap colour scales")
   circlize::colorRamp2(breaks = breaks, colors = colors)
 }
 

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -240,6 +240,7 @@ cnaHeatmap <- function(sce,
                        use_raster = TRUE,
                        row_split = NULL,
                        ...) {
+  require_ns("ComplexHeatmap", "copy-number heatmaps")
   # TODO: Enable multiple annotations
   # TODO: Enable multiple plots layered on top
   # if (is.null(rownames(sce))) {

--- a/R/read_vartrix.R
+++ b/R/read_vartrix.R
@@ -120,6 +120,7 @@ read_vartrix <- function(dir_path = NULL,
 }
 
 vcf_to_df <- function(vcf, verbose = FALSE) {
+  require_ns("vcfR", "reading phased/germline VCFs")
   vcf <- vcfR::read.vcfR(file = vcf, verbose = verbose)
   gts <- vcfR::extract.gt(vcf, element = "GT", return.alleles = F)[, 1] %>% as.factor()
   alleles <- vcfR::extract.gt(vcf, element = "GT", return.alleles = T)[, 1] %>% stringr::str_split_fixed(string = ., pattern = "/|\\|", n = 2)

--- a/R/utils.R
+++ b/R/utils.R
@@ -392,3 +392,18 @@ mixed_sort <- function(x) x[mixed_order(x)]
 chr_reorder <- function(chrs) {
   mixed_sort(chrs)
 }
+
+#' Require a Suggested package or abort with an actionable message
+#'
+#' @param pkg Package name
+#' @param purpose Short description of what it is needed for
+#' @noRd
+require_ns <- function(pkg, purpose = NULL) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    cli::cli_abort(c(
+      "Package {.pkg {pkg}} is required{if (!is.null(purpose)) paste0(' for ', purpose) else ''} but is not installed.",
+      i = "Install it with {.code BiocManager::install(\"{pkg}\")} or {.code install.packages(\"{pkg}\")}."
+    ))
+  }
+  invisible(TRUE)
+}


### PR DESCRIPTION
Moves heavyweight, feature-specific Bioconductor packages out of hard Imports so they install only when the relevant feature is used — a further install/CI reduction on top of #26.

- `EnsDb.Hsapiens.v86` (~1 GB), `GGally` → Suggests (already `requireNamespace`-guarded)
- `ComplexHeatmap`, `circlize`, `vcfR` → Suggests + new guards (`cnaHeatmap`, `logr_col_fun`/`counts_col_fun`, `vcf_to_df`) via a `require_ns()` helper that aborts with an actionable install message

The core `run_scatools` pipeline touches none of these, so default installs get lighter with no loss of core functionality.

R CMD check (R 4.3): **0 errors, 0 warnings, 3 cosmetic NOTEs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)