### PR TITLE
fix(binning): handle fragment cut-sites outside all bins

### DIFF
--- a/R/bin_utils.R
+++ b/R/bin_utils.R
@@ -151,14 +151,19 @@ bin_frags_chr <- function(fragments_chr,
     )
   )
 
-  # Match Cells
+  # Match Cells (one entry per fragment)
   matchID <- S4Vectors::match(mcols(fragments_chr)$barcode, cells)
 
-  # Create Sparse Matrix
+  # Create Sparse Matrix. Each overlap hit contributes one count to (bin, cell):
+  # i = the overlapped bin (subjectHits), j = the cell of the overlapping
+  # fragment (matchID indexed by queryHits). Cut-sites that fall outside all
+  # bins (e.g. centromeric gaps in arm-aware bins) simply produce no hit, so we
+  # must index by the actual hits rather than assume one hit per fragment.
+  # sparseMatrix sums duplicate (i, j) pairs, giving per-bin per-cell counts.
   mat <- Matrix::sparseMatrix(
     i = c(S4Vectors::to(start_hits), S4Vectors::to(end_hits)),
-    j = as.vector(c(matchID, matchID)),
-    x = rep(1, 2 * length(fragments_chr)),
+    j = c(matchID[S4Vectors::from(start_hits)], matchID[S4Vectors::from(end_hits)]),
+    x = 1,
     dims = c(length(bins_chr), length(cells))
   )
 

--- a/tests/testthat/test-binning.R
+++ b/tests/testthat/test-binning.R
@@ -1,0 +1,25 @@
+test_that("bin_frags_chr handles cut-sites that fall outside all bins", {
+  # Two bins on chr1 with a gap (101-200) between them — mimics arm-aware bins
+  # that don't cover centromeres. A fragment landing in the gap must not break
+  # the sparse-matrix construction.
+  bins <- GenomicRanges::GRanges(
+    "chr1",
+    IRanges::IRanges(start = c(1, 201), end = c(100, 300))
+  )
+  frags <- GenomicRanges::GRanges(
+    "chr1",
+    IRanges::IRanges(start = c(10, 150, 250), end = c(50, 160, 260)),
+    barcode = c("cellA", "cellB", "cellA")
+  )
+  cells <- c("cellA", "cellB")
+
+  expect_no_error(mat <- bin_frags_chr(frags, bins = bins, cells = cells))
+  expect_equal(dim(mat), c(2L, 2L))
+
+  m <- as.matrix(mat)
+  # frag1 (cellA) start+end both in bin1 -> 2; frag3 (cellA) both in bin2 -> 2;
+  # frag2 (cellB) lands in the gap -> contributes nothing.
+  expect_equal(unname(m["chr1_1_100", "cellA"]), 2)
+  expect_equal(unname(m["chr1_201_300", "cellA"]), 2)
+  expect_equal(sum(m[, "cellB"]), 0)
+})


### PR DESCRIPTION
Fixes a crash in the core binning, found by running `run_scatools` on real 10x PBMC data.

### Bug
`bin_frags_chr()` built the sparse count matrix assuming **every** fragment's start and end overlap exactly one bin:
```r
j = c(matchID, matchID), x = rep(1, 2 * length(fragments_chr))
```
But arm-aware bins have **gaps** (centromeres/telomeres), so real fragments landing in a gap produce no overlap — leaving `i` shorter than `j`/`x`:
```
Error in Matrix::sparseMatrix(...): length(x) must not exceed length(i)
```
The shipped test fixture never triggered it because it was pre-subset to the bins.

### Fix
Index `j` by the actually-overlapping fragment (`queryHits`) and let `x` recycle, so unmatched cut-sites contribute nothing. `sparseMatrix` still sums duplicate `(i, j)` pairs → per-bin/per-cell counts.

### Validation
- New regression test `test-binning.R` (fragment in a bin gap).
- Full `run_scatools` now completes end-to-end on the 10x PBMC 5k dataset (4,585 cells) in ~3.6 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)