### PR TITLE
benchmark: add make_mini.sh + PBMC dev fixture

### DIFF
--- a/benchmarks/datasets.yaml
+++ b/benchmarks/datasets.yaml
@@ -25,8 +25,28 @@ datasets:
     truth:
       type: karyotype
       value: diploid
-    notes: turnkey; the primary specificity test
-    status: pending
+    notes: turnkey; the primary specificity test. Full run_scatools completes in
+      ~3.6 min (4585 cells, 10Mb bins).
+    status: downloaded
+
+  # Fast dev/CI fixture: a random 300-cell subset of pbmc_5k_normal (real
+  # fragments, NOT pre-filtered to bins, so it exercises the full binning path).
+  # Regenerate with: benchmarks/scripts/make_mini.sh pbmc_5k_normal 300
+  - id: pbmc_5k_normal_mini
+    name: PBMC 5k mini (300-cell subset) — fast dev fixture
+    cancer_type: none
+    assay: scATAC
+    aneuploidy: normal
+    n_cells: 300
+    genome: hg38
+    role: dev_fixture              # full run_scatools in ~27s; for quick checks
+    atac:
+      source: derived             # make_mini.sh pbmc_5k_normal 300
+      format: fragments           # ~40 MB
+    truth:
+      type: karyotype
+      value: diploid
+    status: downloaded
 
   - id: snu601
     name: SNU601 gastric carcinoma (highly aneuploid) — primary benchmark

--- a/benchmarks/scripts/make_mini.sh
+++ b/benchmarks/scripts/make_mini.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Create a subsampled "mini" copy of a benchmark dataset for fast dev/testing.
+#
+# The mini keeps ALL fragments for a random subset of called cells (a *real*
+# subset, NOT pre-filtered to the bins), so it still exercises the full binning
+# path — including cut-sites in bin gaps — in seconds rather than minutes.
+#
+# Usage: make_mini.sh <dataset_id> [n_cells]   (default 300)
+set -euo pipefail
+
+ID="${1:?usage: make_mini.sh <dataset_id> [n_cells]}"
+N="${2:-300}"
+ROOT="${SCATOOLS_BENCH_DATA:-$HOME/work/scatools_benchmark_data}"
+SRC="$ROOT/$ID/atac"
+DST="$ROOT/${ID}_mini/atac"
+mkdir -p "$DST"
+
+if [[ ! -s "$SRC/cells.txt" ]]; then
+  echo "error: $SRC/cells.txt not found (need called-cell barcodes)" >&2
+  exit 1
+fi
+
+shuf -n "$N" "$SRC/cells.txt" > "$DST/cells.txt"
+echo "[${ID}_mini] subsampled $(wc -l < "$DST/cells.txt") cells"
+
+zcat "$SRC/fragments.tsv.gz" \
+  | awk -F'\t' 'FNR==NR{c[$1];next} /^#/{print;next} ($4 in c)' "$DST/cells.txt" - \
+  | gzip > "$DST/fragments.tsv.gz"
+
+echo "[${ID}_mini] fragments: $(zcat "$DST/fragments.tsv.gz" | grep -vc '^#') rows, $(du -h "$DST/fragments.tsv.gz" | cut -f1)"


### PR DESCRIPTION
Adds a fast dev/debug fixture, per the idea of "small dataset for code checks, full version for speed/real runs."

- **`make_mini.sh <dataset> [n]`** — subsamples a dataset to `n` random called cells, keeping **all** their fragments (a real subset, *not* pre-filtered to bins — so it still exercises the full binning path, unlike the shipped `inst/extdata` fixture that hid the arm-gap binning bug).
- **`pbmc_5k_normal_mini`** registered in `datasets.yaml` (`role: dev_fixture`).

Timing: full `run_scatools` in **~27 s** (300 cells) vs **~3.6 min** (4,585 cells).

Data lives outside git under `SCATOOLS_BENCH_DATA`; only the script + registry entry are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)