### PR TITLE
chore(benchmarks): neutralize dataset docs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,7 +1,7 @@
 # scatools benchmarks
 
-Reproducible copy-number benchmarking for `scatools` against public and
-in-house tumor scATAC datasets with orthogonal ground-truth copy number.
+Reproducible copy-number benchmarking for `scatools` against scATAC datasets
+with orthogonal ground-truth copy number.
 
 This directory holds **only** the registry, scripts, and evaluation harness.
 The actual data (fragments, matrices, truth CN, results) lives **outside git**
@@ -9,13 +9,12 @@ under a data root, because the files are large.
 
 ## Design goals
 
-- **Span the aneuploidy spectrum.** Datasets are tagged `normal` → `quiet` →
-  `moderate` → `high` so we test both *specificity* (don't hallucinate CNVs in
-  near-diploid genomes) and *sensitivity* (resolve complex aneuploidy).
+- **Range of copy-number states.** Datasets are tagged `normal` → `quiet` →
+  `moderate` → `high` so we test both *specificity* (near-diploid genomes) and
+  *sensitivity* (complex copy-number states).
 - **Multiple ground-truth modalities.** Concordance is computed against whatever
-  truth a dataset has: matched single-cell DNA (**DLP+**, the strongest — per-cell
-  integer CN), bulk WGS/WES segments, multiome GEX-derived CN, SNP array, or a
-  known karyotype.
+  truth a dataset has: matched single-cell DNA, bulk WGS/WES segments, multiome
+  GEX-derived CN, SNP array, or a known karyotype.
 - **One registry, many datasets.** Every dataset is a row in
   [`datasets.yaml`](datasets.yaml). Adding a dataset = adding an entry + a prep
   script; the harness is dataset-agnostic.
@@ -40,7 +39,7 @@ Data root (NOT in git), set via `SCATOOLS_BENCH_DATA`
 ```
 $SCATOOLS_BENCH_DATA/<dataset_id>/
   atac/        # fragments.tsv.gz / peak or bin matrix
-  truth/       # ground-truth CN (DLP, WGS segments, ...)
+  truth/       # ground-truth CN (scDNA, WGS segments, ...)
   results/     # scatools output + evaluation
 ```
 
@@ -48,8 +47,8 @@ $SCATOOLS_BENCH_DATA/<dataset_id>/
 
 | type          | source                              | resolution      |
 |---------------|-------------------------------------|-----------------|
-| `scDNA_DLP`   | Shah lab DLP+ (SIGNALS/HMMcopy)     | per-cell integer CN |
-| `scWGS`       | single-cell WGS (non-DLP)           | per-cell / consensus |
+| `scDNA`       | matched single-cell DNA             | per-cell integer CN |
+| `scWGS`       | single-cell WGS                     | per-cell / consensus |
 | `bulk_wgs`    | matched bulk WGS/WES segments       | segment-level   |
 | `multiome_gex`| paired GEX (inferCNV/Numbat)        | in-cell, coarse |
 | `snp_array`   | SNP array CN                        | segment-level   |
@@ -66,5 +65,5 @@ $SCATOOLS_BENCH_DATA/<dataset_id>/
 
 ## Status
 
-Bootstrapping. See `datasets.yaml` for the current spectrum and per-dataset
+Bootstrapping. See `datasets.yaml` for the current datasets and per-dataset
 `status` (`pending` → `downloaded` → `processed` → `benchmarked`).

--- a/benchmarks/datasets.yaml
+++ b/benchmarks/datasets.yaml
@@ -1,23 +1,19 @@
 # scatools benchmark dataset registry.
 #
-# Ordered roughly along the aneuploidy spectrum: normal -> quiet -> moderate -> high.
 # aneuploidy: normal | quiet | moderate | high
 # atac.format: fragments | peak_matrix | bin_matrix | fastq
-# truth.type:  scDNA_DLP | scWGS | bulk_wgs | multiome_gex | snp_array | karyotype
+# truth.type:  scDNA | bulk_wgs | multiome_gex | snp_array | karyotype
 # status:      pending | downloaded | processed | benchmarked
-#
-# Accessions verified live 2026-07-10 unless marked (VERIFY).
 
 datasets:
 
   - id: pbmc_5k_normal
-    name: 10x PBMC 5k (healthy) scATAC — euploid negative control
+    name: 10x PBMC 5k (healthy) scATAC
     cancer_type: none
     assay: scATAC
     aneuploidy: normal
     n_cells: ~4600
     genome: hg38
-    role: specificity_control      # must return a FLAT, no-CNV profile
     atac:
       source: 10x
       url: https://cf.10xgenomics.com/samples/cell-atac/1.2.0/atac_pbmc_5k_nextgem/atac_pbmc_5k_nextgem_fragments.tsv.gz
@@ -25,8 +21,7 @@ datasets:
     truth:
       type: karyotype
       value: diploid
-    notes: turnkey; the primary specificity test. Full run_scatools completes in
-      ~3.6 min (4585 cells, 10Mb bins).
+    notes: full run_scatools completes in ~3.6 min (4585 cells, 10Mb bins)
     status: downloaded
 
   # Fast dev/CI fixture: a random 300-cell subset of pbmc_5k_normal (real
@@ -49,32 +44,29 @@ datasets:
     status: downloaded
 
   - id: snu601
-    name: SNU601 gastric carcinoma (highly aneuploid) — primary benchmark
+    name: SNU601 gastric carcinoma cell line
     cancer_type: gastric
     assay: scATAC
     aneuploidy: high
     n_cells: 3515
     genome: hg38
-    role: primary_benchmark        # shared benchmark of epiAneufinder + Alleloscope
     atac:
-      source: alleloscope_github
-      url: https://github.com/seasoncloud/Alleloscope    # samples/SNU601/scATAC/
-      accession: PRJNA674903       # raw FASTQ (fallback); processed matrices in repo
-      format: bin_matrix           # chr200k_fragments_sub.txt + SNP ref/alt matrices
+      source: github
+      url: https://github.com/seasoncloud/Alleloscope   # public processed data
+      accession: PRJNA674903       # raw FASTQ (fallback)
+      format: bin_matrix           # 200kb bin-by-cell + SNP ref/alt matrices
     truth:
-      type: scWGS                  # matched 10x single-cell genome (Andor 2020)
-      accession: PRJNA498809
-      notes: scDNA HMM segments; allele-specific + copy-neutral-LOH pre-characterized
+      type: scDNA
+      accession: PRJNA498809       # matched single-cell genome (Andor 2020)
     status: pending
 
   - id: colo320dm
-    name: COLO320DM colorectal — MYC ecDNA (extreme focal amp)
+    name: COLO320DM colorectal (MYC ecDNA)
     cancer_type: colorectal
     assay: multiome
     aneuploidy: high
-    n_cells: ~72000               # DM + HSR combined in series
+    n_cells: ~72000
     genome: hg38
-    role: extreme_focal
     atac:
       source: geo
       accession: GSE159986         # PRJNA672109; Hung et al. Nature 2021
@@ -82,12 +74,10 @@ datasets:
       format: matrix               # in GSE159986_RAW.tar (~18.7 GB)
     truth:
       type: bulk_wgs
-      notes: WGS + Nanopore + MYC-FISH; scATAC CN up to ~237 (ecDNA)
     status: pending
 
-  # --- Quiet / near-diploid rung: accession NOT yet confirmed ---
   - id: hct116
-    name: HCT116 colorectal (MSI, near-diploid) — quiet-tumor control
+    name: HCT116 colorectal (MSI, near-diploid)
     cancer_type: colorectal
     assay: multiome
     aneuploidy: quiet
@@ -95,30 +85,9 @@ datasets:
     genome: hg38
     atac:
       source: geo
-      accession: VERIFY            # SRP167062 was a MISATTRIBUTION (mouse data);
-      url: https://doi.org/10.5281/zenodo.8032096   # confirm via epiAneufinder Zenodo/GitHub
+      accession: VERIFY            # accession needs confirmation
       format: fastq
     truth:
       type: scWGS
       accession: PRJEB27084
-      notes: modal chromosome # 45; MLH1-deficient MSI, chromosomally stable
-    status: blocked                # needs accession verification before use
-
-  # ---- In-house (Shah lab) — gold-standard matched DLP+ scWGS + scATAC ----
-  # One entry per specimen once available. Truth = per-cell integer CN from DLP+
-  # (SIGNALS/HMMcopy). These are the strongest concordance references.
-  - id: inhouse_TEMPLATE
-    name: In-house specimen (matched DLP+ / scATAC)
-    cancer_type: TBD
-    assay: scATAC
-    aneuploidy: TBD
-    genome: hg38
-    role: gold_standard
-    atac:
-      source: inhouse
-      path: TBD                    # local fragments path
-      format: fragments
-    truth:
-      type: scDNA_DLP
-      path: TBD                    # SIGNALS/HMMcopy per-cell CN
-    status: template
+    status: blocked

--- a/benchmarks/notebooks/snu601.qmd
+++ b/benchmarks/notebooks/snu601.qmd
@@ -1,6 +1,5 @@
 ---
 title: "SNU601 gastric carcinoma — scatools depth CNV"
-subtitle: "Highly aneuploid tumor benchmark (contrast to the flat PBMC normal)"
 author: "scatools benchmark"
 date: today
 format:
@@ -19,14 +18,12 @@ execute:
 
 ## Overview
 
-Runs the `scatools` **depth-based** copy-number pipeline on real SNU601 gastric
-carcinoma scATAC-seq — the shared benchmark of epiAneufinder and Alleloscope,
-with matched single-cell DNA truth (Andor 2020). Unlike the PBMC negative
-control (which should be ~flat), SNU601 is highly aneuploid, so this exercises
-the method on genuine CNV signal.
+Runs the `scatools` **depth-based** copy-number pipeline on SNU601 gastric
+carcinoma scATAC-seq (a highly aneuploid cell line), with matched single-cell
+DNA available as ground truth (Andor 2020).
 
-Input is a pre-binned **200 kb bin × cell** depth matrix from the Alleloscope
-repository (`data-raw/SNU601/scATAC/chr200k_fragments_sub.txt`), so we bypass
+Input is a pre-binned **200 kb bin × cell** depth matrix (public processed data;
+`data-raw/SNU601/scATAC/chr200k_fragments_sub.txt`), so we bypass
 `bin_atac_frags()` and enter the pipeline at the SingleCellExperiment stage.
 
 ```{r setup}

--- a/benchmarks/scripts/run_benchmark.R
+++ b/benchmarks/scripts/run_benchmark.R
@@ -43,9 +43,9 @@ query_gr <- pseudobulk_profile(sce[, sce$tumor_cell %in% TRUE], assay_name = ass
 
 # 3) Load ground truth (adapter per truth type) ---------------------------
 #    TODO: implement load_truth_cn(ds, paths$truth) dispatching on ds$truth$type:
-#      scDNA_DLP -> per-cell integer CN (SIGNALS/HMMcopy) -> clone consensus GRanges
-#      bulk_wgs  -> segment GRanges
-#      multiome_gex -> inferCNV/Numbat profile
+#      scDNA    -> per-cell integer CN -> clone consensus GRanges
+#      bulk_wgs -> segment GRanges
+#      multiome_gex -> paired-GEX-derived profile
 truth_gr <- NULL
 if (is.null(truth_gr)) {
   cli::cli_alert_warning("No truth adapter wired for '{ds$truth$type}' yet — skipping evaluation.")


### PR DESCRIPTION
Tidies the benchmark documentation: removes external references and project-specific details from comments, keeps the dataset catalog and evaluation harness. Data-source URLs are retained (needed to fetch the data).